### PR TITLE
Add trait methods to `alloy_network_primitives::TransactionResponse`

### DIFF
--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -1,5 +1,5 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -315,6 +315,10 @@ impl Transaction for TxEip1559 {
     }
 
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/eip1559.rs
+++ b/crates/consensus/src/transaction/eip1559.rs
@@ -290,6 +290,10 @@ impl Transaction for TxEip1559 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -254,6 +254,10 @@ impl Transaction for TxEip2930 {
         self.gas_price
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }

--- a/crates/consensus/src/transaction/eip2930.rs
+++ b/crates/consensus/src/transaction/eip2930.rs
@@ -1,5 +1,5 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -279,6 +279,10 @@ impl Transaction for TxEip2930 {
     }
 
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -237,6 +237,13 @@ impl Transaction for TxEip4844Variant {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::TxEip4844(tx) => tx.max_fee_per_blob_gas(),
+            Self::TxEip4844WithSidecar(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
     fn to(&self) -> TxKind {
         match self {
             Self::TxEip4844(tx) => tx.to,
@@ -700,6 +707,10 @@ impl Transaction for TxEip4844 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        Some(self.max_fee_per_blob_gas)
+    }
+
     fn to(&self) -> TxKind {
         self.to.into()
     }
@@ -963,6 +974,10 @@ impl Transaction for TxEip4844WithSidecar {
 
     fn priority_fee_or_price(&self) -> u128 {
         self.tx.priority_fee_or_price()
+    }
+
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        self.tx.max_fee_per_blob_gas()
     }
 
     fn to(&self) -> TxKind {

--- a/crates/consensus/src/transaction/eip4844.rs
+++ b/crates/consensus/src/transaction/eip4844.rs
@@ -1,6 +1,6 @@
 use crate::{EncodableSignature, SignableTransaction, Signed, Transaction, TxType};
 
-use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB};
+use alloy_eips::{eip2930::AccessList, eip4844::DATA_GAS_PER_BLOB, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Address, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header};
 use core::mem;
@@ -282,6 +282,10 @@ impl Transaction for TxEip4844Variant {
             Self::TxEip4844(tx) => tx.blob_versioned_hashes(),
             Self::TxEip4844WithSidecar(tx) => tx.blob_versioned_hashes(),
         }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
     }
 }
 
@@ -734,6 +738,10 @@ impl Transaction for TxEip4844 {
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
         Some(self.blob_versioned_hashes.iter().collect())
     }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
+    }
 }
 
 impl Encodable for TxEip4844 {
@@ -1002,6 +1010,10 @@ impl Transaction for TxEip4844WithSidecar {
 
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
         self.tx.blob_versioned_hashes()
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        None
     }
 }
 

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -314,6 +314,10 @@ impl Transaction for TxEip7702 {
         self.max_priority_fee_per_gas
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }

--- a/crates/consensus/src/transaction/eip7702.rs
+++ b/crates/consensus/src/transaction/eip7702.rs
@@ -341,6 +341,10 @@ impl Transaction for TxEip7702 {
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
         None
     }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        Some(&self.authorization_list)
+    }
 }
 
 impl SignableTransaction<Signature> for TxEip7702 {

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -544,6 +544,16 @@ impl Transaction for TxEnvelope {
             Self::Eip7702(tx) => tx.tx().blob_versioned_hashes(),
         }
     }
+
+    fn authorization_list(&self) -> Option<&[alloy_eips::eip7702::SignedAuthorization]> {
+        match self {
+            Self::Legacy(tx) => tx.tx().authorization_list(),
+            Self::Eip2930(tx) => tx.tx().authorization_list(),
+            Self::Eip1559(tx) => tx.tx().authorization_list(),
+            Self::Eip4844(tx) => tx.tx().authorization_list(),
+            Self::Eip7702(tx) => tx.tx().authorization_list(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/consensus/src/transaction/envelope.rs
+++ b/crates/consensus/src/transaction/envelope.rs
@@ -465,6 +465,16 @@ impl Transaction for TxEnvelope {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip2930(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip1559(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip4844(tx) => tx.tx().max_fee_per_blob_gas(),
+            Self::Eip7702(tx) => tx.tx().max_fee_per_blob_gas(),
+        }
+    }
+
     fn input(&self) -> &[u8] {
         match self {
             Self::Legacy(tx) => tx.tx().input(),

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -1,6 +1,6 @@
 use core::mem;
 
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, Bytes, ChainId, Signature, TxKind, B256, U256};
 use alloy_rlp::{length_of_length, BufMut, Decodable, Encodable, Header, Result};
 
@@ -257,6 +257,10 @@ impl Transaction for TxLegacy {
     }
 
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>> {
+        None
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
         None
     }
 }

--- a/crates/consensus/src/transaction/legacy.rs
+++ b/crates/consensus/src/transaction/legacy.rs
@@ -232,6 +232,10 @@ impl Transaction for TxLegacy {
         self.gas_price
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        None
+    }
+
     fn to(&self) -> TxKind {
         self.to
     }

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -1,7 +1,7 @@
 //! Transaction types.
 
 use crate::Signed;
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{keccak256, ChainId, TxKind, B256, U256};
 use core::any;
 
@@ -124,6 +124,11 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     /// Blob versioned hashes for eip4844 transaction. For previous transaction types this is
     /// `None`.
     fn blob_versioned_hashes(&self) -> Option<Vec<&B256>>;
+
+    /// Returns the [`SignedAuthorization`] list of the transaction.
+    ///
+    /// Returns `None` if this transaction is not EIP-7702.
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]>;
 }
 
 /// A signable transaction.

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -117,7 +117,7 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     /// Returns the transaction type
     fn ty(&self) -> u8;
 
-    /// Returns the EIP2930 `access_list` for the particular transaction type. Returns `None` for
+    /// Returns the EIP-2930 `access_list` for the particular transaction type. Returns `None` for
     /// older transaction types.
     fn access_list(&self) -> Option<&AccessList>;
 

--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -56,13 +56,20 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     ///
     /// For legacy transactions this is `gas_price`.
     ///
-    /// This is also commonly referred to as the "Gas Fee Cap" (`GasFeeCap`).
+    /// This is also commonly referred to as the "Gas Fee Cap".
     fn max_fee_per_gas(&self) -> u128;
 
     /// Returns the EIP-1559 Priority fee the caller is paying to the block author.
     ///
     /// This will return `None` for non-EIP1559 transactions
     fn max_priority_fee_per_gas(&self) -> Option<u128>;
+
+    /// Max fee per blob gas for EIP-4844 transaction.
+    ///
+    /// Returns `None` for non-eip4844 transactions.
+    ///
+    /// This is also commonly referred to as the "Blob Gas Fee Cap".
+    fn max_fee_per_blob_gas(&self) -> Option<u128>;
 
     /// Return the max priority fee per gas if the transaction is an EIP-1559 transaction, and
     /// otherwise return the gas price.

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -205,6 +205,16 @@ impl Transaction for TypedTransaction {
         }
     }
 
+    fn max_fee_per_blob_gas(&self) -> Option<u128> {
+        match self {
+            Self::Legacy(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip2930(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip1559(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip4844(tx) => tx.max_fee_per_blob_gas(),
+            Self::Eip7702(tx) => tx.max_fee_per_blob_gas(),
+        }
+    }
+
     fn to(&self) -> TxKind {
         match self {
             Self::Legacy(tx) => tx.to(),

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -2,7 +2,7 @@ use crate::{
     transaction::eip4844::{TxEip4844, TxEip4844Variant, TxEip4844WithSidecar},
     Transaction, TxEip1559, TxEip2930, TxEip7702, TxEnvelope, TxLegacy, TxType,
 };
-use alloy_eips::eip2930::AccessList;
+use alloy_eips::{eip2930::AccessList, eip7702::SignedAuthorization};
 use alloy_primitives::{ChainId, TxKind};
 
 /// The TypedTransaction enum represents all Ethereum transaction request types.
@@ -272,6 +272,16 @@ impl Transaction for TypedTransaction {
             Self::Eip1559(tx) => tx.blob_versioned_hashes(),
             Self::Eip4844(tx) => tx.blob_versioned_hashes(),
             Self::Eip7702(tx) => tx.blob_versioned_hashes(),
+        }
+    }
+
+    fn authorization_list(&self) -> Option<&[SignedAuthorization]> {
+        match self {
+            Self::Legacy(tx) => tx.authorization_list(),
+            Self::Eip2930(tx) => tx.authorization_list(),
+            Self::Eip1559(tx) => tx.authorization_list(),
+            Self::Eip4844(tx) => tx.authorization_list(),
+            Self::Eip7702(tx) => tx.authorization_list(),
         }
     }
 }

--- a/crates/network-primitives/Cargo.toml
+++ b/crates/network-primitives/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 alloy-serde.workspace = true
+alloy-consensus.workspace = true
 
 serde.workspace = true
 

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -47,7 +47,7 @@ pub trait TransactionResponse {
     fn input(&self) -> &Bytes;
 
     /// Returns the gas price formatted for the RPC response.
-    fn gas_price(tx: impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128;
+    fn gas_price(tx: &impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128;
 
     /// Returns the max fee per gas.
     fn max_fee_per_gas(tx: impl alloy_consensus::Transaction) -> Option<u128>;
@@ -88,7 +88,7 @@ impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {
         self.inner.input()
     }
 
-    fn gas_price(tx: impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128 {
+    fn gas_price(tx: &impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128 {
         T::gas_price(tx, base_fee)
     }
 

--- a/crates/network-primitives/src/traits.rs
+++ b/crates/network-primitives/src/traits.rs
@@ -1,4 +1,5 @@
-use alloy_primitives::{Address, BlockHash, Bytes, TxHash, U256};
+use alloy_consensus::Signed;
+use alloy_primitives::{Address, BlockHash, Bytes, TxHash, B256, U256};
 use alloy_serde::WithOtherFields;
 
 /// Receipt JSON-RPC response.
@@ -44,6 +45,22 @@ pub trait TransactionResponse {
     /// Input data
     #[doc(alias = "calldata")]
     fn input(&self) -> &Bytes;
+
+    /// Returns the gas price formatted for the RPC response.
+    fn gas_price(tx: impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128;
+
+    /// Returns the max fee per gas.
+    fn max_fee_per_gas(tx: impl alloy_consensus::Transaction) -> Option<u128>;
+
+    /// Assemble from signed transaction.
+    fn fill(
+        signed_tx: Signed<impl alloy_consensus::Transaction>,
+        signer: Address,
+        block_hash: Option<B256>,
+        block_number: Option<u64>,
+        base_fee: Option<u64>,
+        transaction_index: Option<usize>,
+    ) -> Self;
 }
 
 impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {
@@ -69,6 +86,32 @@ impl<T: TransactionResponse> TransactionResponse for WithOtherFields<T> {
 
     fn input(&self) -> &Bytes {
         self.inner.input()
+    }
+
+    fn gas_price(tx: impl alloy_consensus::Transaction, base_fee: Option<u64>) -> u128 {
+        T::gas_price(tx, base_fee)
+    }
+
+    fn max_fee_per_gas(tx: impl alloy_consensus::Transaction) -> Option<u128> {
+        T::max_fee_per_gas(tx)
+    }
+
+    fn fill(
+        signed_tx: Signed<impl alloy_consensus::Transaction>,
+        signer: Address,
+        block_hash: Option<B256>,
+        block_number: Option<u64>,
+        base_fee: Option<u64>,
+        transaction_index: Option<usize>,
+    ) -> Self {
+        WithOtherFields::new(T::fill(
+            signed_tx,
+            signer,
+            block_hash,
+            block_number,
+            base_fee,
+            transaction_index,
+        ))
     }
 }
 

--- a/crates/rpc-types-eth/src/transaction/mod.rs
+++ b/crates/rpc-types-eth/src/transaction/mod.rs
@@ -376,11 +376,7 @@ impl TransactionResponse for Transaction<alloy_primitives::Signature> {
             transaction_index: transaction_index.map(|idx| idx as u64),
             // EIP-4844 fields
             max_fee_per_blob_gas: tx.max_fee_per_blob_gas(),
-            blob_versioned_hashes: tx
-                .blob_versioned_hashes()
-                .into_iter()
-                .clone()
-                .collect::<Vec<_>>(),
+            blob_versioned_hashes: tx.blob_versioned_hashes().into_iter().cloned().collect(),
             authorization_list: tx.authorization_list().map(|l| l.to_vec()),
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/alloy-rs/core/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Removing the optimism feature from `reth-rpc-types-compat` in a simple way, requires implementing the conversion from a signed transaction into an rpc transaction object, into the crates that define the associated types of `alloy_network::Network`. Otherwise, we are not able to access the additional OP fields for example.

Moving into `reth-optimsim-rpc` is not an option, since neither the trait for conversion nor the `<op_alloy_network::Optimism as Network>::TransactionResponse` type are defined in the `reth-optimsim-rpc` crate

## Solution

Adds trait methods to `alloy_network_primitives::TransactionResponse` for filling a `alloy_network_primitives::Transaction` from `alloy_consensus::Signed<impl alloy_consensus::Transaction>`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
